### PR TITLE
Make deck iterable in AoC 2020 day 22

### DIFF
--- a/correct_programs/aoc2020/day_22_crab_combat.py
+++ b/correct_programs/aoc2020/day_22_crab_combat.py
@@ -1,5 +1,5 @@
 import re
-from typing import Tuple, List, Sequence, overload, Union, Any, Final
+from typing import Tuple, List, Sequence, overload, Union, Any, Final, Iterator
 
 from icontract import require, ensure, DBC
 
@@ -57,6 +57,9 @@ class Deck(DBC):
 
     def __len__(self) -> int:
         return len(self.cards)
+
+    def __iter__(self) -> Iterator[int]:
+        return self.cards.__iter__()
 
     # fmt: off
     @require(


### PR DESCRIPTION
This patch makes the deck of cards iterable in the solution for AoC 2020
day 22. Previously, mypy failed on this example.