### PR TITLE
Fix potential hash collision in AoC 2020 day 20

### DIFF
--- a/correct_programs/aoc2020/day_20_jurassic_jigsaw.py
+++ b/correct_programs/aoc2020/day_20_jurassic_jigsaw.py
@@ -73,7 +73,12 @@ class Tile(DBC):
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Tile):
-            return hash(self) == hash(other)
+            return (
+                self.top == other.top
+                and self.right == other.right
+                and self.bottom == other.bottom
+                and self.left == other.left
+            )
 
         return self == other
 


### PR DESCRIPTION
This patch fixes a potential hash collision. We used `hash(.)` for
equality check, which would cause a bug if there are hash collisions.