### PR TITLE
May AoC 2020 day 25 testable

### DIFF
--- a/correct_programs/aoc2020/day_25_combo_breaker.py
+++ b/correct_programs/aoc2020/day_25_combo_breaker.py
@@ -6,11 +6,7 @@ TESTING_WITH_ICONTRACT_HYPOTHESIS = False
 
 
 # fmt: off
-@require(
-    lambda loop_size:
-    loop_size >= 0
-    and (not TESTING_WITH_ICONTRACT_HYPOTHESIS or loop_size < 10000)
-)
+@require(lambda loop_size: loop_size >= 0)
 @require(lambda subject: subject >= 0)
 @ensure(lambda result: 0 <= result < 20201227)
 # fmt: on

--- a/tests/correct_programs/aoc2020/test_day_25_combo_breaker.py
+++ b/tests/correct_programs/aoc2020/test_day_25_combo_breaker.py
@@ -1,21 +1,21 @@
 import unittest
 
 import icontract_hypothesis
+from icontract import require, ensure
 
 from correct_programs.aoc2020 import day_25_combo_breaker
 
 
 class TestWithIcontractHypothesis(unittest.TestCase):
-    def setUp(self) -> None:
-        day_25_combo_breaker.TESTING_WITH_ICONTRACT_HYPOTHESIS = True
-
-    def tearDown(self) -> None:
-        day_25_combo_breaker.TESTING_WITH_ICONTRACT_HYPOTHESIS = False
-
     def test_functions(self) -> None:
-        for func in [
-            day_25_combo_breaker.transform,
-        ]:
+        # We need to add more constraints so that the function is testable.
+        @require(lambda loop_size: loop_size >= 0)
+        @require(lambda loop_size: loop_size < 1000)
+        @require(lambda subject: subject >= 0)
+        def transform_testable(subject: int, loop_size: int) -> int:
+            return day_25_combo_breaker.transform(subject, loop_size)
+
+        for func in [transform_testable]:
             try:
                 icontract_hypothesis.test_with_inferred_strategy(func)
             except Exception as error:


### PR DESCRIPTION
The function `transform` is not generally testable as the loop size
needs to be small (otherwise the function never terminates).

This patch introduces an additional testable `transform` function that
*strengthens* the pre-conditions.