### PR TITLE
Remove inheritance from `typing` generic types

### DIFF
--- a/correct_programs/aoc2020/day_10_adapter_array.py
+++ b/correct_programs/aoc2020/day_10_adapter_array.py
@@ -43,7 +43,7 @@ def pairwise(iterable: Iterable[T]) -> Iterable[Tuple[T, T]]:
         previous = current
 
 
-class HistogramOfDeltas(DBC, Mapping[int, int]):
+class HistogramOfDeltas(DBC):
     @require(lambda mapping: all(delta > 0 for delta in mapping.keys()))
     @require(lambda mapping: all(count >= 0 for count in mapping.values()))
     def __new__(cls, mapping: Mapping[int, int]) -> "HistogramOfDeltas":

--- a/correct_programs/common.py
+++ b/correct_programs/common.py
@@ -1,10 +1,10 @@
 """Provide common functionality shared among all the solutions."""
-from typing import Sequence, cast, overload, Union
+from typing import Sequence, cast, overload, Union, Iterator
 
 from icontract import DBC, require
 
 
-class Lines(DBC, Sequence[str]):
+class Lines(DBC):
     """Represent a sequence of text lines."""
 
     # fmt: off
@@ -64,4 +64,8 @@ class Lines(DBC, Sequence[str]):
 
     def __len__(self) -> int:
         """Return the number of the lines."""
+        raise NotImplementedError("Only for type annotations")
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over the lines."""
         raise NotImplementedError("Only for type annotations")


### PR DESCRIPTION
Registering types with Hypothesis which inherit from `typing` generic
types causes unexpected Hypothesis strategies, see [1]. Hence this patch
removes the inheritance and implements the remainder of the methods so
that duck typing works with mypy.

[1]: https://github.com/HypothesisWorks/hypothesis/issues/2951