### PR TITLE
Fix misconception about walrus operator

### DIFF
--- a/correct_programs/aoc2020/day_22_crab_combat.py
+++ b/correct_programs/aoc2020/day_22_crab_combat.py
@@ -67,7 +67,7 @@ class Deck(DBC):
         (
                 sum := list(self.cards) + other.cards,
                 len(set(sum)) == len(sum)
-        ),
+        )[1],
         "Unique cards after the addition")
     # fmt: on
     def __add__(self, other: "Deck") -> "Deck":

--- a/correct_programs/ethz_eprog_2019/exercise_02/problem_02.py
+++ b/correct_programs/ethz_eprog_2019/exercise_02/problem_02.py
@@ -42,16 +42,6 @@ TRAILING_SPACE_RE = re.compile(r"\s$")
 @ensure(
     lambda result:
     all(
-        (stripped := line.strip(),
-         (half := len(stripped),
-          line[:half] == line[half:]))
-        for line in result
-    ),
-    "Horizontal symmetry"
-)
-@ensure(
-    lambda result:
-    all(
         len(line.strip()) % 2 == 0
         for line in result
     )

--- a/correct_programs/ethz_eprog_2019/exercise_02/problem_03.py
+++ b/correct_programs/ethz_eprog_2019/exercise_02/problem_03.py
@@ -53,7 +53,10 @@ ONLY_DASHES_RE = re.compile(r"^[-]+\Z")
 @ensure(
     lambda result:
     all(
-        (center := int(len(line) / 2), line[:center] == line[center + 1:])
+        (
+                center := int(len(line) / 2),
+                line[:center] == line[center + 1:]
+        )[1]
         for line in result
     ),
     "Horizontal symmetry"

--- a/correct_programs/ethz_eprog_2019/exercise_02/problem_05_02.py
+++ b/correct_programs/ethz_eprog_2019/exercise_02/problem_05_02.py
@@ -33,15 +33,19 @@ PATTERN_RE = re.compile(r"^(?P<leftpad>[.]*)\d+(?P<rightpad>[.]*)$")
 @require(lambda height: height <= 9)
 @ensure(
     lambda height, result:
-    (middle := int(height / 2),
-     ALL_NUMBERS_RE.match(result[middle]))
+    (
+            middle := int(height / 2),
+            ALL_NUMBERS_RE.match(result[middle])
+    )[1]
 )
 @ensure(
     lambda height, result:
     all(
-        (mtch := PATTERN_RE.match(line),
-         mtch is not None
-         and mtch.group('leftpad') == mtch.group('rightpad'))
+        (
+                mtch := PATTERN_RE.match(line),
+                mtch is not None
+                and mtch.group('leftpad') == mtch.group('rightpad')
+        )[1]
         for line in result))
 @ensure(lambda height, result: all(len(line) == height for line in result))
 @ensure(lambda height, result: len(result) == height)

--- a/correct_programs/ethz_eprog_2019/exercise_05/problem_03.py
+++ b/correct_programs/ethz_eprog_2019/exercise_05/problem_03.py
@@ -100,8 +100,10 @@ class BinRanges(DBC):
     )
     @require(
         lambda lower_bound, upper_bound, bin_count:
-        (bin_width := (upper_bound - lower_bound) / bin_count,
-         bin_width != 0),
+        (
+                bin_width := (upper_bound - lower_bound) / bin_count,
+                bin_width != 0
+        )[1],
         "Bin width not numerically zero"
     )
     @ensure(

--- a/correct_programs/ethz_eprog_2019/exercise_06/problem_05.py
+++ b/correct_programs/ethz_eprog_2019/exercise_06/problem_05.py
@@ -36,7 +36,7 @@ from icontract import require, ensure
     (
             clock_hour := hour if hour < 12 else hour - 12,
             clock_hour / 12 * 360 <= result[0] < (clock_hour + 1) / 12 * 360
-    ),
+    )[1],
     "Hour hand between two hour ticks"
 )
 @ensure(

--- a/correct_programs/ethz_eprog_2019/exercise_11/problem_01.py
+++ b/correct_programs/ethz_eprog_2019/exercise_11/problem_01.py
@@ -128,7 +128,7 @@ GRADING_RE = compile_grading_re()
     lambda result: (
         identifiers := [grading.identifier for grading in result],
         len(identifiers) == len(set(identifiers)),
-    ),
+    )[1],
     "Unique identifiers",
 )
 @ensure(lambda lines, result: len(result) == len(lines))
@@ -156,14 +156,18 @@ def parse(lines: Lines) -> List[Grading]:
 # fmt: off
 @require(
     lambda gradings:
-    (identifiers := [grading.identifier for grading in gradings],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in gradings],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 @ensure(
     lambda result:
-    (identifiers := [grading.identifier for grading in result],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in result],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 # fmt: on
@@ -179,15 +183,19 @@ def critical(gradings: List[Grading], bound1: Grade, bound2: Decimal) -> List[Gr
 # fmt: off
 @require(
     lambda gradings:
-    (identifiers := [grading.identifier for grading in gradings],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in gradings],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 @require(lambda limit: limit > 0)
 @ensure(
     lambda result:
-    (identifiers := [grading.identifier for grading in result],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in result],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 @ensure(

--- a/correct_programs/ethz_eprog_2019/exercise_12/problem_04.py
+++ b/correct_programs/ethz_eprog_2019/exercise_12/problem_04.py
@@ -68,8 +68,10 @@ class Word(DBC):
 # fmt: off
 @ensure(
     lambda result:
-    (word_texts := [word.text for word in result],
-     len(word_texts) == len(set(word_texts))),
+    (
+            word_texts := [word.text for word in result],
+            len(word_texts) == len(set(word_texts))
+    )[1],
     "No duplicates in words"
 )
 @ensure(
@@ -136,11 +138,13 @@ def tokenize(text: str) -> List[Token]:
 @require(lambda limit: limit > 0)
 @ensure(
     lambda words, result:
-    (word_set := set(words),
-     all(
-         word in word_set  # pylint: disable=used-before-assignment
-         for word in result
-     ))
+    (
+            word_set := set(words),
+            all(
+                word in word_set  # pylint: disable=used-before-assignment
+                for word in result
+            )
+    )[1]
 )
 @ensure(
     lambda result:

--- a/recorded_failures/ethz_eprog_2019/exercise_02/problem_02/forgot_to_enforce_vertical_symmetry.py
+++ b/recorded_failures/ethz_eprog_2019/exercise_02/problem_02/forgot_to_enforce_vertical_symmetry.py
@@ -58,9 +58,13 @@ TRAILING_SPACE_RE = re.compile(r'\s$')
 @ensure(
     lambda result:
     all(
-        (stripped := line.strip(),
-         (half := len(stripped),
-          line[:half] == line[half:]))
+        (
+                stripped := line.strip(),
+                (
+                        half := len(stripped),
+                        line[:half] == line[half:]
+                )[1]
+        )[1]
         for line in result
     ),
     "Horizontal symmetry"

--- a/recorded_failures/ethz_eprog_2019/exercise_02/problem_03/horizontal_padding_was_wrong.py
+++ b/recorded_failures/ethz_eprog_2019/exercise_02/problem_03/horizontal_padding_was_wrong.py
@@ -53,7 +53,10 @@ ONLY_DASHES_RE = re.compile(r'^[-]+\Z')
 @ensure(
     lambda result:
     all(
-        (center := int(len(line) / 2), line[:center] == line[center + 1:])
+        (
+                center := int(len(line) / 2),
+                line[:center] == line[center + 1:]
+        )[1]
         for line in result
     ),
     "Horizontal symmetry"

--- a/recorded_failures/ethz_eprog_2019/exercise_05/problem_03/binary_search_wrong.py
+++ b/recorded_failures/ethz_eprog_2019/exercise_05/problem_03/binary_search_wrong.py
@@ -97,8 +97,10 @@ class BinRanges(DBC):
     )
     @require(
         lambda lower_bound, upper_bound, bin_count:
-        (bin_width := (upper_bound - lower_bound) / bin_count,
-         bin_width != 0),
+        (
+                bin_width := (upper_bound - lower_bound) / bin_count,
+                bin_width != 0
+        )[1],
         "Bin width not numerically zero"
     )
     @ensure(
@@ -155,7 +157,7 @@ class BinRanges(DBC):
 
             # We need to account for numerical imprecision with summation
             # so that the last bin indeed matches the exact upper bound.
-            if i < bin_count -1:
+            if i < bin_count - 1:
                 ranges.append(Range(start=start, end=end))
             else:
                 ranges.append(Range(start=start, end=upper_bound))

--- a/recorded_failures/ethz_eprog_2019/exercise_05/problem_03/incorrectly_handled_edge_case_with_a_single_value.py
+++ b/recorded_failures/ethz_eprog_2019/exercise_05/problem_03/incorrectly_handled_edge_case_with_a_single_value.py
@@ -107,8 +107,10 @@ class BinRanges(DBC):
     )
     @require(
         lambda lower_bound, upper_bound, bin_count:
-        (bin_width := (upper_bound - lower_bound) / bin_count,
-         bin_width != 0),
+        (
+                bin_width := (upper_bound - lower_bound) / bin_count,
+                bin_width != 0
+        )[1],
         "Bin width not numerically zero"
     )
     @ensure(
@@ -193,6 +195,7 @@ class BinRanges(DBC):
         """Iterate over the lines."""
         raise NotImplementedError("Only for type annotations")
 
+
 # fmt: off
 @require(lambda value: not math.isnan(value))
 @ensure(
@@ -216,7 +219,7 @@ class BinRanges(DBC):
     "value not covered in ranges => bin not found"
 )
 # fmt: on
-def bin_index(ranges: BinRanges, value: float)->int:
+def bin_index(ranges: BinRanges, value: float) -> int:
     # Edge cases
     if value < ranges[0].start:
         return -1
@@ -258,6 +261,7 @@ def bin_index(ranges: BinRanges, value: float)->int:
         width = last - first + 1
         assert width < old_width, "Loop invariant: the index range is getting smaller"
 
+
 @invariant(lambda self: all(count >= 0 for count in self.counts))
 class Histogram:
     @require(lambda ranges: len(ranges) > 0)
@@ -267,15 +271,16 @@ class Histogram:
 
     @require(lambda value: math.isnan(value))
     @require(lambda self, value: self.ranges[0].start <= value < self.ranges[-1].end)
-    def add(self, value: float)->None:
+    def add(self, value: float) -> None:
         index = bin_index(self.ranges, value)
         assert 0 <= index < len(self.counts)
 
         self.counts[index] += 1
 
-    def items(self)->Iterator[Tuple[Range, int]]:
+    def items(self) -> Iterator[Tuple[Range, int]]:
         assert len(self.ranges) == len(self.counts)
         return zip(self.ranges, self.counts)
+
 
 # fmt: off
 @ensure(
@@ -285,7 +290,7 @@ class Histogram:
 # fmt: on
 def compute_histogram(measurements: Measurements) -> List[Tuple[Range, int]]:
     lower_bound = math.floor(min(measurements))
-    upper_bound= math.ceil(max(measurements))
+    upper_bound = math.ceil(max(measurements))
 
     if lower_bound == upper_bound:
         upper_bound += 1

--- a/recorded_failures/ethz_eprog_2019/exercise_05/problem_03/unhandled_numerical_imprecision_on_the_last_bin.py
+++ b/recorded_failures/ethz_eprog_2019/exercise_05/problem_03/unhandled_numerical_imprecision_on_the_last_bin.py
@@ -97,8 +97,10 @@ class BinRanges(DBC):
     )
     @require(
         lambda lower_bound, upper_bound, bin_count:
-        (bin_width := (upper_bound - lower_bound) / bin_count,
-         bin_width != 0),
+        (
+                bin_width := (upper_bound - lower_bound) / bin_count,
+                bin_width != 0
+        )[1],
         "Bin width not numerically zero"
     )
     @ensure(

--- a/recorded_failures/ethz_eprog_2019/exercise_11/problem_01/got_postcondition_on_top_gradings_wrong.py
+++ b/recorded_failures/ethz_eprog_2019/exercise_11/problem_01/got_postcondition_on_top_gradings_wrong.py
@@ -128,8 +128,10 @@ GRADING_RE = compile_grading_re()
 @require(lambda lines: all(GRADING_RE.match(line) for line in lines))
 @ensure(
     lambda result:
-    (identifiers := [grading.identifier for grading in result],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in result],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Unique identifiers"
 )
 @ensure(lambda lines, result: len(result) == len(lines))
@@ -157,14 +159,18 @@ def parse(lines: Lines) -> List[Grading]:
 # fmt: off
 @require(
     lambda gradings:
-    (identifiers := [grading.identifier for grading in gradings],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in gradings],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 @ensure(
     lambda result:
-    (identifiers := [grading.identifier for grading in result],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in result],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 # fmt: on
@@ -180,15 +186,19 @@ def critical(gradings: List[Grading], bound1: Grade, bound2: Decimal) -> List[Gr
 # fmt: off
 @require(
     lambda gradings:
-    (identifiers := [grading.identifier for grading in gradings],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in gradings],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 @require(lambda limit: limit > 0)
 @ensure(
     lambda result:
-    (identifiers := [grading.identifier for grading in result],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in result],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 # ERROR:

--- a/recorded_failures/ethz_eprog_2019/exercise_11/problem_01/missed_edge_case_in_postcondition_where_all_grades_are_zero.py
+++ b/recorded_failures/ethz_eprog_2019/exercise_11/problem_01/missed_edge_case_in_postcondition_where_all_grades_are_zero.py
@@ -129,8 +129,10 @@ GRADING_RE = compile_grading_re()
 @require(lambda lines: all(GRADING_RE.match(line) for line in lines))
 @ensure(
     lambda result:
-    (identifiers := [grading.identifier for grading in result],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in result],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Unique identifiers"
 )
 @ensure(lambda lines, result: len(result) == len(lines))
@@ -159,14 +161,18 @@ def parse(lines: Lines) -> List[Grading]:
 @require(lambda bound2: Decimal(0.0) <= bound2 <= Decimal(6.0))
 @require(
     lambda gradings:
-    (identifiers := [grading.identifier for grading in gradings],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in gradings],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 @ensure(
     lambda result:
-    (identifiers := [grading.identifier for grading in result],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in result],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 # fmt: on
@@ -182,15 +188,19 @@ def critical(gradings: List[Grading], bound1: Grade, bound2: Decimal) -> List[Gr
 # fmt: off
 @require(
     lambda gradings:
-    (identifiers := [grading.identifier for grading in gradings],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in gradings],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 @require(lambda limit: limit > 0)
 @ensure(
     lambda result:
-    (identifiers := [grading.identifier for grading in result],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in result],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 @ensure(

--- a/recorded_failures/ethz_eprog_2019/exercise_11/problem_01/missed_to_require_not_a_nan_for_grades_since_unhashable.py
+++ b/recorded_failures/ethz_eprog_2019/exercise_11/problem_01/missed_to_require_not_a_nan_for_grades_since_unhashable.py
@@ -119,8 +119,10 @@ GRADING_RE = compile_grading_re()
 @require(lambda lines: all(GRADING_RE.match(line) for line in lines))
 @ensure(
     lambda result:
-    (identifiers := [grading.identifier for grading in result],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in result],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Unique identifiers"
 )
 @ensure(lambda lines, result: len(result) == len(lines))
@@ -149,14 +151,18 @@ def parse(lines: Lines) -> List[Grading]:
 @require(lambda bound2: Decimal(0.0) <= bound2 <= Decimal(6.0))
 @require(
     lambda gradings:
-    (identifiers := [grading.identifier for grading in gradings],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in gradings],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 @ensure(
     lambda result:
-    (identifiers := [grading.identifier for grading in result],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in result],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 # fmt: on
@@ -172,15 +178,19 @@ def critical(gradings: List[Grading], bound1: Grade, bound2: Decimal) -> List[Gr
 # fmt: off
 @require(
     lambda gradings:
-    (identifiers := [grading.identifier for grading in gradings],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in gradings],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 @require(lambda limit: limit > 0)
 @ensure(
     lambda result:
-    (identifiers := [grading.identifier for grading in result],
-     len(identifiers) == len(set(identifiers))),
+    (
+            identifiers := [grading.identifier for grading in result],
+            len(identifiers) == len(set(identifiers))
+    )[1],
     "Students appear only once"
 )
 @ensure(

--- a/recorded_failures/ethz_eprog_2019/exercise_12/problem_04/forgot_about_the_edge_case_when_all_tokens_unique.py
+++ b/recorded_failures/ethz_eprog_2019/exercise_12/problem_04/forgot_about_the_edge_case_when_all_tokens_unique.py
@@ -54,8 +54,10 @@ class Word(DBC):
 # fmt: off
 @ensure(
     lambda result:
-    (word_texts := [word.text for word in result],
-     len(word_texts) == len(set(word_texts))),
+    (
+            word_texts := [word.text for word in result],
+            len(word_texts) == len(set(word_texts))
+    )[1],
     "No duplicates in words"
 )
 @ensure(
@@ -124,11 +126,13 @@ def tokenize(text: str) -> List[Token]:
 @require(lambda limit: limit > 0)
 @ensure(
     lambda words, result:
-    (word_set := set(words),
-     all(
-         word in word_set
-         for word in result
-     ))
+    (
+            word_set := set(words),
+            all(
+                word in word_set
+                for word in result
+            )
+    )[1]
 )
 @ensure(
     lambda result:

--- a/recorded_failures/ethz_eprog_2019/exercise_12/problem_04/missed_the_edge_case_when_top_words_are_less_equal.py
+++ b/recorded_failures/ethz_eprog_2019/exercise_12/problem_04/missed_the_edge_case_when_top_words_are_less_equal.py
@@ -50,18 +50,21 @@ class Word(DBC):
                 < other.last_occurrence - other.first_occurrence
         )
 
-    def __repr__(self)->str:
+    def __repr__(self) -> str:
         return (
-                f"Word("
-                f"{self.first_occurrence!r}, {self.last_occurrence!r}, {self.text!r}"
-                f")"
+            f"Word("
+            f"{self.first_occurrence!r}, {self.last_occurrence!r}, {self.text!r}"
+            f")"
         )
+
 
 # fmt: off
 @ensure(
     lambda result:
-    (word_texts := [word.text for word in result],
-     len(word_texts) == len(set(word_texts))),
+    (
+            word_texts := [word.text for word in result],
+            len(word_texts) == len(set(word_texts))
+    )[1],
     "No duplicates in words"
 )
 @ensure(
@@ -119,11 +122,13 @@ def tokenize(text: str) -> List[Token]:
 @require(lambda limit: limit > 0)
 @ensure(
     lambda words, result:
-    (word_set := set(words),
-     all(
-         word in word_set
-         for word in result
-     ))
+    (
+            word_set := set(words),
+            all(
+                word in word_set
+                for word in result
+            )
+    )[1]
 )
 # ERROR:
 # icontract.errors.ViolationError:


### PR DESCRIPTION
Coming from Golang I got wrong how the walrus operator is used in
Python. This patch fixes all the contracts where the walrus operator was
mistakenly used.