### PR TITLE
Fix ETHZ Eprog 2019 Exercise 11 Problem 01

### DIFF
--- a/correct_programs/ethz_eprog_2019/exercise_11/problem_01.py
+++ b/correct_programs/ethz_eprog_2019/exercise_11/problem_01.py
@@ -126,7 +126,7 @@ GRADING_RE = compile_grading_re()
 @require(lambda lines: all(GRADING_RE.match(line) for line in lines))
 @ensure(
     lambda result: (
-        identifiers := [grading.name for grading in result],
+        identifiers := [grading.identifier for grading in result],
         len(identifiers) == len(set(identifiers)),
     )[1],
     "Unique identifiers",
@@ -157,7 +157,7 @@ def parse(lines: Lines) -> List[Grading]:
 @require(
     lambda gradings:
     (
-            identifiers := [grading.name for grading in gradings],
+            identifiers := [grading.identifier for grading in gradings],
             len(identifiers) == len(set(identifiers))
     )[1],
     "Students appear only once"
@@ -165,7 +165,7 @@ def parse(lines: Lines) -> List[Grading]:
 @ensure(
     lambda result:
     (
-            identifiers := [grading.name for grading in result],
+            identifiers := [grading.identifier for grading in result],
             len(identifiers) == len(set(identifiers))
     )[1],
     "Students appear only once"
@@ -184,7 +184,7 @@ def critical(gradings: List[Grading], bound1: Grade, bound2: Decimal) -> List[Gr
 @require(
     lambda gradings:
     (
-            identifiers := [grading.name for grading in gradings],
+            identifiers := [grading.identifier for grading in gradings],
             len(identifiers) == len(set(identifiers))
     )[1],
     "Students appear only once"
@@ -193,7 +193,7 @@ def critical(gradings: List[Grading], bound1: Grade, bound2: Decimal) -> List[Gr
 @ensure(
     lambda result:
     (
-            identifiers := [grading.name for grading in result],
+            identifiers := [grading.identifier for grading in result],
             len(identifiers) == len(set(identifiers))
     )[1],
     "Students appear only once"


### PR DESCRIPTION
The property `name` had been renamed to `identifier`, but it went
unnoticed as:

1) PyCharm did not propagate the changes, and
2) the remote CI is still out-of-order (due to pending upgrades in
   icontract and icontract-hypothesis).

This patch fixes the rename and the unit tests pass again.