### PR TITLE
Upgrade icontract and icontract-hypothesis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-icontract>=2.5.0
-icontract-hypothesis>=1.1.3
+icontract>=2.5.3
+icontract-hypothesis>=1.1.4
 crosshair-tool>=0.0.11


### PR DESCRIPTION
This patch upgrades icontract and icontract-hypothesis to latest
versions (2.5.3 and 1.1.4, respectively) so that the continous
integration finally passes on GitHub as well.