### PR TITLE
Limit the test runtime of ETHZ Eprog 2019 E06P04

### DIFF
--- a/tests/correct_programs/ethz_eprog_2019/exercise_06/test_problem_04.py
+++ b/tests/correct_programs/ethz_eprog_2019/exercise_06/test_problem_04.py
@@ -47,7 +47,7 @@ class TestWithIcontractHypothesis(unittest.TestCase):
             )
         )
 
-        for _ in range(100):
+        for _ in range(10):
             methods = all_methods
             if lst.is_empty():
                 methods = methods_if_empty


### PR DESCRIPTION
This patch limits the number of steps in the random walk when testing
the state of the linked list. Running the test remote on GitHub caused
problems.