### PR TITLE
Fix `.readthedocs.yml` to use requirements

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,8 +17,6 @@ formats:
 python:
    version: 3.8
    install:
-   - method: pip
-     path: .
    - requirements: requirements.txt
    - requirements: requirements-doc.txt
 

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -2,4 +2,4 @@ sphinx>=3.4.3,<4
 sphinx-autodoc-typehints>=1.11.1
 sphinx-rtd-theme>=0.5.1,<1
 autodocsumm>=0.2.2,<1
-sphinx-icontract>=2.0.2
+sphinx-icontract>=2.0.3


### PR DESCRIPTION
This patch fixes the readthedocs config since it seems that the
requirements have not been installed properly.