### PR TITLE
Add readthedocs badge to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,9 @@ Python-by-Contract Corpus
 .. image:: https://coveralls.io/repos/github/mristin/python-by-contract-corpus/badge.svg?branch=main
     :target: https://coveralls.io/github/mristin/python-by-contract-corpus?branch=main
 
+.. image:: https://readthedocs.org/projects/python-by-contract-corpus/badge/?version=latest&style=plastic
+    :target: https://python-by-contract-corpus.readthedocs.io/en/latest/
+
 We present here a corpus of Python programs annotated with `contracts`_.
 
 The corpus includes:


### PR DESCRIPTION
This adds the badge so that readers can instantly click for
documentation.