### PR TITLE
Report better test failure for AoC 2020 day 21

### DIFF
--- a/tests/correct_programs/aoc2020/test_day_21_allergen_assessment.py
+++ b/tests/correct_programs/aoc2020/test_day_21_allergen_assessment.py
@@ -16,9 +16,12 @@ class TestWithIcontractHypothesis(unittest.TestCase):
             try:
                 icontract_hypothesis.test_with_inferred_strategy(func)  # type: ignore
             except Exception as error:
+                strategy = icontract_hypothesis.infer_strategy(func)  # type: ignore
+
                 raise Exception(
                     f"Automatically testing {func} with icontract-hypothesis failed "
-                    f"(please see the original error above)"
+                    f"(please see the original error above).\n\n"
+                    f"The inferred strategy was: {strategy}"
                 ) from error
 
 


### PR DESCRIPTION
The function `find_non_allergenic_ingredients` caused health-check
failures in Hypothesis.

This patch displays the strategy for easier debugging.