### PR TITLE
Disable icontract-hypothesis on AoC 2020 day 23

### DIFF
--- a/tests/correct_programs/aoc2020/test_day_21_allergen_assessment.py
+++ b/tests/correct_programs/aoc2020/test_day_21_allergen_assessment.py
@@ -10,7 +10,8 @@ class TestWithIcontractHypothesis(unittest.TestCase):
     def test_functions(self) -> None:
         for func in [
             day_21_allergen_assessment.serialize_entry,
-            day_21_allergen_assessment.find_non_allergenic_ingredients,
+            # NOTE: uncomment once icontract-hypothesis is powerful enough
+            # day_21_allergen_assessment.find_non_allergenic_ingredients,
             day_21_allergen_assessment.solve,
         ]:
             try:


### PR DESCRIPTION
The function `find_non_allergenic_ingredients` causes too many
health-check failures. We are disabling it for now till
icontract-hypothesis is improved.