### PR TITLE
Compare against naive in ETHZ Eprog Ex. 4.1

### DIFF
--- a/correct_programs/ethz_eprog_2019/exercise_04/problem_01.py
+++ b/correct_programs/ethz_eprog_2019/exercise_04/problem_01.py
@@ -23,8 +23,26 @@ def find(a: List[int], x: int) -> int:
     return -1
 
 
+def naive_is_prime(number: int) -> bool:
+    """Check naively whether the ``number`` is a prime number."""
+    result = True
+    for another in range(number - 1, 1, -1):
+        if number % another == 0:
+            result = False
+            break
+
+    return result
+
+
 # fmt: off
 @require(lambda limit: limit > 1)
+@ensure(
+    lambda result:
+    all(
+        naive_is_prime(number)
+        for number in result
+    )
+)
 @ensure(
     lambda limit, result:
     all(

--- a/tests/correct_programs/ethz_eprog_2019/exercise_04/test_problem_01.py
+++ b/tests/correct_programs/ethz_eprog_2019/exercise_04/test_problem_01.py
@@ -7,26 +7,9 @@ from icontract import require, ensure
 from correct_programs.ethz_eprog_2019.exercise_04 import problem_01
 
 
-def naive_is_prime(number: int) -> bool:
-    """Check naively whether the ``number`` is a prime number."""
-    result = True
-    for another in range(number - 1, 1, -1):
-        if number % another == 0:
-            result = False
-            break
-
-    return result
-
-
 class TestWithIcontractHypothesis(unittest.TestCase):
     def test_functions(self) -> None:
-        # fmt: off
         @require(lambda limit: 2 < limit < 1000)
-        @ensure(
-            lambda result:
-            all(naive_is_prime(number) for number in result)
-        )
-        # fmt: on
         def sieve_with_restricted_input(limit: int) -> List[int]:
             return problem_01.sieve(limit=limit)
 


### PR DESCRIPTION
This patch adds a nice example how we can compare against a naive
implementation in the contract.