### PR TITLE
Make ETHZ Eprog Ex 8.5 more precise (#94)

### DIFF
--- a/correct_programs/aoc2020/day_11_seating_system.py
+++ b/correct_programs/aoc2020/day_11_seating_system.py
@@ -48,16 +48,27 @@ class Layout:
     height: Final[int]  #: height of the layout
     width: Final[int]  #: width of the layout
 
+    # fmt: off
     @require(
-        lambda table: len(table) > 0
+        lambda table:
+        len(table) > 0
         and len(table[0]) > 0
-        and all(len(row) == len(table[0]) for row in table)
+        and all(
+            len(row) == len(table[0])
+            for row in table
+        )
     )
     @require(
-        lambda table: all(re.match(r"^[L#.]\Z", cell) for row in table for cell in row)
+        lambda table:
+        all(
+            re.fullmatch(r"[L#.]", cell)
+            for row in table
+            for cell in row
+        )
     )
     @ensure(lambda self: self.height == len(self.table))
     @ensure(lambda self: len(self.table) > 0 and self.width == len(self.table[0]))
+    # fmt: on
     def __init__(self, table: List[List[str]]) -> None:
         """Initialize with the given values."""
         self.table = table

--- a/correct_programs/ethz_eprog_2019/exercise_08/problem_05.py
+++ b/correct_programs/ethz_eprog_2019/exercise_08/problem_05.py
@@ -32,6 +32,10 @@ class Position:
         self.x = x
         self.y = y
 
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        return f"{self.__class__.__name__}({self.x!r}, {self.y!r})"
+
 
 # fmt: off
 @ensure(lambda result: len(result) == 4)
@@ -55,7 +59,8 @@ class Position:
 @ensure(
     lambda pos, result:
     all(
-        (next_pos.x == pos.x) ^ (next_pos.y == pos.y)
+        (next_pos.x == pos.x and next_pos.y != pos.y)
+        ^ (next_pos.x != pos.x and next_pos.y == pos.y)
         for next_pos in result
     ),
     "Next is either in x- or in y-direction"


### PR DESCRIPTION
This patch makes the contracts in `list_next_positions` a bit more
specific so that we can use them as examples in the recipes.