### PR TITLE
Fix minor issues with the in-line literals in docs

### DIFF
--- a/python_by_contract_corpus/ethz_eprog_2019/exercise_03/problem_01.py
+++ b/python_by_contract_corpus/ethz_eprog_2019/exercise_03/problem_01.py
@@ -3,9 +3,10 @@ For a given ``n``, compute the sum:
 
 .. code-block::
 
-    s = 1 / (1**2) + 1 / (2**2) + ... + 1 / (n**2)
+    s = 1 / (1**2) + 1 / (2**2) + … + 1 / (n**2)
 
 For ``n == 0``, the sum should be 0.
+
 For ``n == 4``, the sum should be about 1.42.
 """
 
@@ -17,7 +18,7 @@ from icontract import require, ensure
 @ensure(lambda result: result >= 0)
 def compute(n: int) -> float:
     """
-    Compute the recursive sum ``s = 1 / (1**2) + 1 / (2**2) + ... + 1 / (n**2)``
+    Compute the recursive sum ``s = 1 / (1**2) + 1 / (2**2) + … + 1 / (n**2)``.
 
     >>> compute(0)
     0

--- a/python_by_contract_corpus/ethz_eprog_2019/exercise_08/problem_01.py
+++ b/python_by_contract_corpus/ethz_eprog_2019/exercise_08/problem_01.py
@@ -13,7 +13,7 @@ Here are a couple of examples:
 * ``s = "abbbc", t = "cab", k = 1``. The result is ``True``.
 * ``s = "abbbbc", t = "cab", k = 1``. The result if ``False``. The distance between
   either "a" and "b" or "b" and "c" is larger than 1.
-* ``s = "abc"
+* ``s = "abc"``
 
 """
 


### PR DESCRIPTION
We had a couple of unclosed and/or invalid in-line literals in the
docstrings. This patch fixes them so that the documentation renders
correctly.