### PR TITLE
Release 2021.7.10rc1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,8 @@
+2021.7.10rc1
+============
+This is the very first release candidate.
+Some exercises are still missing and minor tweaks prior to our Europython 2021 talk are expected.
+
+We still need to decide how we want to structure the buggy programs.
+At the moment, they are stored as "recorded failures" in the repository.
+We deliberately exclude them from the distribution as they are not really release-worthy.


### PR DESCRIPTION
This is the very first release candidate.  Some exercises are still
missing and minor tweaks prior to our Europython 2021 talk are expected.

We still need to decide how we want to structure the buggy programs.
At the moment, they are stored as "recorded failures" in the repository.
We deliberately exclude them from the distribution as they are not
really release-worthy.