### PR TITLE
Fix ETHZ Eprog 2021 Ex. 08 Prob. 03

### DIFF
--- a/python_by_contract_corpus/correct/ethz_eprog_2019/exercise_08/problem_03.py
+++ b/python_by_contract_corpus/correct/ethz_eprog_2019/exercise_08/problem_03.py
@@ -118,7 +118,7 @@ class Customer:
 
 
 # fmt: off
-@require(lambda steps: steps >= 0)
+@require(lambda steps: steps >= 1)
 @ensure(
     lambda result:
     all(

--- a/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_08/problem_03/did_not_get_finished_and_max_length_right.py
+++ b/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_08/problem_03/did_not_get_finished_and_max_length_right.py
@@ -118,7 +118,7 @@ class Customer:
 
 
 # fmt: off
-@require(lambda steps: steps >= 0)
+@require(lambda steps: steps >= 1)
 @ensure(
     lambda result:
     all(

--- a/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_08/problem_03/got_upper_bound_of_avg_wrong.py
+++ b/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_08/problem_03/got_upper_bound_of_avg_wrong.py
@@ -118,7 +118,7 @@ class Customer:
 
 
 # fmt: off
-@require(lambda steps: steps >= 0)
+@require(lambda steps: steps >= 1)
 @ensure(
     lambda result:
     all(

--- a/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_08/problem_03/got_upper_bound_of_max_wrong.py
+++ b/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_08/problem_03/got_upper_bound_of_max_wrong.py
@@ -118,7 +118,7 @@ class Customer:
 
 
 # fmt: off
-@require(lambda steps: steps >= 0)
+@require(lambda steps: steps >= 1)
 @ensure(
     lambda result:
     all(

--- a/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_08/problem_03/missed_to_restrict_number_of_steps_to_1_for_meaningful_statistics.py
+++ b/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_08/problem_03/missed_to_restrict_number_of_steps_to_1_for_meaningful_statistics.py
@@ -49,13 +49,10 @@ class Specs(DBC):
         lambda max_cart_size:
         max_cart_size >= 1
     )
-    # ERROR (mristin, 2021-06-03):
-    # I missed to specify that the number of checkouts must not be zero.
-    # Something like:
-    # @require(
-    #     lambda checkout_efficiencies:
-    #     len(checkout_efficiencies) > 0
-    # )
+    @require(
+        lambda checkout_efficiencies:
+        len(checkout_efficiencies) > 0
+    )
     # fmt: on
     def __init__(
         self,
@@ -121,7 +118,12 @@ class Customer:
 
 
 # fmt: off
-@require(lambda steps: steps >= 1)
+# ERROR (mristin, 2021-12-12):
+# I forgot to restrict the number of steps above 1 such that :py:func`statistics.mean`
+# can return a meaningful result. I should have written a pre-condition such as
+# the following one instead:
+# @require(lambda steps: steps >= 1)
+@require(lambda steps: steps >= 0)
 @ensure(
     lambda result:
     all(

--- a/tests/correct/ethz_eprog_2019/exercise_08/test_problem_03.py
+++ b/tests/correct/ethz_eprog_2019/exercise_08/test_problem_03.py
@@ -8,7 +8,7 @@ from python_by_contract_corpus.correct.ethz_eprog_2019.exercise_08 import proble
 
 class TestWithIcontractHypothesis(unittest.TestCase):
     def test_functions(self) -> None:
-        @require(lambda steps: 0 <= steps < 100)
+        @require(lambda steps: 1 <= steps < 100)
         def restricted_simulate(
             specs: problem_03.Specs, steps: int
         ) -> problem_03.Stats:

--- a/tests/correct/ethz_eprog_2019/exercise_08/test_problem_05.py
+++ b/tests/correct/ethz_eprog_2019/exercise_08/test_problem_05.py
@@ -8,7 +8,7 @@ from python_by_contract_corpus.correct.ethz_eprog_2019.exercise_08 import proble
 
 class TestWithIcontractHypothesis(unittest.TestCase):
     def test_functions(self) -> None:
-        @require(lambda trials: 0 <= trials < 10)
+        @require(lambda trials: 1 <= trials < 10)
         @require(lambda grid_size: 3 <= grid_size < 10)
         @require(lambda grid_size: grid_size % 2 == 1)
         def restricted_simulate(trials: int, grid_size: int) -> float:


### PR DESCRIPTION
This patch fixes a bug in the solution where statistics could not be
computed on empty samples (when the number of steps in the simulation
was set to 0). We also propagate the change down to the curated
incorrect solutions.