### PR TITLE
Fix ETHZ Eprog 2019 Ex. 12 Prob. 1

### DIFF
--- a/python_by_contract_corpus/correct/ethz_eprog_2019/exercise_12/problem_01.py
+++ b/python_by_contract_corpus/correct/ethz_eprog_2019/exercise_12/problem_01.py
@@ -14,7 +14,7 @@ user input/output is out-of-scope of this corpus.)
 # parsing modules, respectively.
 #
 # We opt for the former solution (all the code in the same module) for simplicity.
-
+import abc
 import enum
 import io
 import math
@@ -255,12 +255,22 @@ class Identifier(DBC, str):
         return cast(Identifier, value)
 
 
-class Node:
+class Node(DBC):
     """Represent a node of an abstract syntax tree (AST) of a program."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Expr(Node):
     """Represent a mathematical expression in an AST."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Constant(Expr, DBC):
@@ -408,8 +418,13 @@ class Call(Expr, DBC):
 class Statement(Node):
     """Represent a statement in the AST."""
 
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
-class Assign(Statement, DBC):
+
+class Assign(Statement):
     """Represent an assignment statement."""
 
     def __init__(self, target: Identifier, expr: Expr) -> None:

--- a/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/forgot_to_append_statements_to_body.py
+++ b/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/forgot_to_append_statements_to_body.py
@@ -14,7 +14,7 @@ user input/output is out-of-scope of this corpus.)
 # parsing modules, respectively.
 #
 # We opt for the former solution (all the code in the same module) for simplicity.
-
+import abc
 import enum
 import io
 import math
@@ -255,12 +255,22 @@ class Identifier(DBC, str):
         return cast(Identifier, value)
 
 
-class Node:
+class Node(DBC):
     """Represent a node of an abstract syntax tree (AST) of a program."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Expr(Node):
     """Represent a mathematical expression in an AST."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Constant(Expr, DBC):
@@ -408,8 +418,13 @@ class Call(Expr, DBC):
 class Statement(Node):
     """Represent a statement in the AST."""
 
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
-class Assign(Statement, DBC):
+
+class Assign(Statement):
     """Represent an assignment statement."""
 
     def __init__(self, target: Identifier, expr: Expr) -> None:

--- a/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/forgot_to_eat_a_semicolon_when_parsing_a_statement.py
+++ b/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/forgot_to_eat_a_semicolon_when_parsing_a_statement.py
@@ -14,7 +14,7 @@ user input/output is out-of-scope of this corpus.)
 # parsing modules, respectively.
 #
 # We opt for the former solution (all the code in the same module) for simplicity.
-
+import abc
 import enum
 import io
 import math
@@ -255,12 +255,22 @@ class Identifier(DBC, str):
         return cast(Identifier, value)
 
 
-class Node:
+class Node(DBC):
     """Represent a node of an abstract syntax tree (AST) of a program."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Expr(Node):
     """Represent a mathematical expression in an AST."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Constant(Expr, DBC):
@@ -408,8 +418,13 @@ class Call(Expr, DBC):
 class Statement(Node):
     """Represent a statement in the AST."""
 
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
-class Assign(Statement, DBC):
+
+class Assign(Statement):
     """Represent an assignment statement."""
 
     def __init__(self, target: Identifier, expr: Expr) -> None:

--- a/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/forgot_to_handle_exponential_form_in_numbers.py
+++ b/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/forgot_to_handle_exponential_form_in_numbers.py
@@ -14,7 +14,7 @@ user input/output is out-of-scope of this corpus.)
 # parsing modules, respectively.
 #
 # We opt for the former solution (all the code in the same module) for simplicity.
-
+import abc
 import enum
 import io
 import math
@@ -255,12 +255,22 @@ class Identifier(DBC, str):
         return cast(Identifier, value)
 
 
-class Node:
+class Node(DBC):
     """Represent a node of an abstract syntax tree (AST) of a program."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Expr(Node):
     """Represent a mathematical expression in an AST."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Constant(Expr, DBC):
@@ -408,8 +418,13 @@ class Call(Expr, DBC):
 class Statement(Node):
     """Represent a statement in the AST."""
 
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
-class Assign(Statement, DBC):
+
+class Assign(Statement):
     """Represent an assignment statement."""
 
     def __init__(self, target: Identifier, expr: Expr) -> None:

--- a/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/forgot_to_handle_plus_in_exponential_form_in_numbers.py
+++ b/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/forgot_to_handle_plus_in_exponential_form_in_numbers.py
@@ -14,7 +14,7 @@ user input/output is out-of-scope of this corpus.)
 # parsing modules, respectively.
 #
 # We opt for the former solution (all the code in the same module) for simplicity.
-
+import abc
 import enum
 import io
 import math
@@ -259,12 +259,22 @@ class Identifier(DBC, str):
         return cast(Identifier, value)
 
 
-class Node:
+class Node(DBC):
     """Represent a node of an abstract syntax tree (AST) of a program."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Expr(Node):
     """Represent a mathematical expression in an AST."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Constant(Expr, DBC):
@@ -412,8 +422,13 @@ class Call(Expr, DBC):
 class Statement(Node):
     """Represent a statement in the AST."""
 
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
-class Assign(Statement, DBC):
+
+class Assign(Statement):
     """Represent an assignment statement."""
 
     def __init__(self, target: Identifier, expr: Expr) -> None:

--- a/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/forgot_to_restrict_inf_in_constants.py
+++ b/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/forgot_to_restrict_inf_in_constants.py
@@ -14,7 +14,7 @@ user input/output is out-of-scope of this corpus.)
 # parsing modules, respectively.
 #
 # We opt for the former solution (all the code in the same module) for simplicity.
-
+import abc
 import enum
 import io
 import math
@@ -260,12 +260,22 @@ class Identifier(DBC, str):
         return cast(Identifier, value)
 
 
-class Node:
+class Node(DBC):
     """Represent a node of an abstract syntax tree (AST) of a program."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Expr(Node):
     """Represent a mathematical expression in an AST."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Constant(Expr, DBC):
@@ -413,8 +423,13 @@ class Call(Expr, DBC):
 class Statement(Node):
     """Represent a statement in the AST."""
 
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
-class Assign(Statement, DBC):
+
+class Assign(Statement):
     """Represent an assignment statement."""
 
     def __init__(self, target: Identifier, expr: Expr) -> None:

--- a/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/got_limit_for_cursor_wrong_in_parse_stmt.py
+++ b/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/got_limit_for_cursor_wrong_in_parse_stmt.py
@@ -14,7 +14,7 @@ user input/output is out-of-scope of this corpus.)
 # parsing modules, respectively.
 #
 # We opt for the former solution (all the code in the same module) for simplicity.
-
+import abc
 import enum
 import io
 import math
@@ -255,12 +255,22 @@ class Identifier(DBC, str):
         return cast(Identifier, value)
 
 
-class Node:
+class Node(DBC):
     """Represent a node of an abstract syntax tree (AST) of a program."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Expr(Node):
     """Represent a mathematical expression in an AST."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Constant(Expr, DBC):
@@ -408,8 +418,13 @@ class Call(Expr, DBC):
 class Statement(Node):
     """Represent a statement in the AST."""
 
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
-class Assign(Statement, DBC):
+
+class Assign(Statement):
     """Represent an assignment statement."""
 
     def __init__(self, target: Identifier, expr: Expr) -> None:

--- a/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/got_tokenization_of_newline_wrong.py
+++ b/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/got_tokenization_of_newline_wrong.py
@@ -14,7 +14,7 @@ user input/output is out-of-scope of this corpus.)
 # parsing modules, respectively.
 #
 # We opt for the former solution (all the code in the same module) for simplicity.
-
+import abc
 import enum
 import io
 import math
@@ -259,12 +259,22 @@ class Identifier(DBC, str):
         return cast(Identifier, value)
 
 
-class Node:
+class Node(DBC):
     """Represent a node of an abstract syntax tree (AST) of a program."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Expr(Node):
     """Represent a mathematical expression in an AST."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Constant(Expr, DBC):
@@ -412,8 +422,13 @@ class Call(Expr, DBC):
 class Statement(Node):
     """Represent a statement in the AST."""
 
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
-class Assign(Statement, DBC):
+
+class Assign(Statement):
     """Represent an assignment statement."""
 
     def __init__(self, target: Identifier, expr: Expr) -> None:

--- a/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/got_unparsing_of_unary_operation_wrong.py
+++ b/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/got_unparsing_of_unary_operation_wrong.py
@@ -14,7 +14,7 @@ user input/output is out-of-scope of this corpus.)
 # parsing modules, respectively.
 #
 # We opt for the former solution (all the code in the same module) for simplicity.
-
+import abc
 import enum
 import io
 import math
@@ -255,12 +255,22 @@ class Identifier(DBC, str):
         return cast(Identifier, value)
 
 
-class Node:
+class Node(DBC):
     """Represent a node of an abstract syntax tree (AST) of a program."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Expr(Node):
     """Represent a mathematical expression in an AST."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Constant(Expr, DBC):
@@ -408,8 +418,13 @@ class Call(Expr, DBC):
 class Statement(Node):
     """Represent a statement in the AST."""
 
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
-class Assign(Statement, DBC):
+
+class Assign(Statement):
     """Represent an assignment statement."""
 
     def __init__(self, target: Identifier, expr: Expr) -> None:

--- a/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/invalid_regexp_for_floating_point_numbers.py
+++ b/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/invalid_regexp_for_floating_point_numbers.py
@@ -14,7 +14,7 @@ user input/output is out-of-scope of this corpus.)
 # parsing modules, respectively.
 #
 # We opt for the former solution (all the code in the same module) for simplicity.
-
+import abc
 import enum
 import io
 import math
@@ -260,12 +260,22 @@ class Identifier(DBC, str):
         return cast(Identifier, value)
 
 
-class Node:
+class Node(DBC):
     """Represent a node of an abstract syntax tree (AST) of a program."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Expr(Node):
     """Represent a mathematical expression in an AST."""
+
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
 
 class Constant(Expr, DBC):
@@ -413,8 +423,13 @@ class Call(Expr, DBC):
 class Statement(Node):
     """Represent a statement in the AST."""
 
+    @abc.abstractmethod
+    def __repr__(self) -> str:
+        """Represent the instance as a string for debugging."""
+        raise NotImplementedError()
 
-class Assign(Statement, DBC):
+
+class Assign(Statement):
     """Represent an assignment statement."""
 
     def __init__(self, target: Identifier, expr: Expr) -> None:

--- a/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/missed_to_make_Statement_abstract.py
+++ b/python_by_contract_corpus/incorrect_from_recorded/ethz_eprog_2019/exercise_12/problem_01/missed_to_make_Statement_abstract.py
@@ -418,10 +418,16 @@ class Call(Expr, DBC):
 class Statement(Node):
     """Represent a statement in the AST."""
 
-    @abc.abstractmethod
-    def __repr__(self) -> str:
-        """Represent the instance as a string for debugging."""
-        raise NotImplementedError()
+    # ERROR (mristin, 2021-12-12):
+    # I forgot to make :py:class:`Statement` abstract so icontract-hypothesis (and
+    # possibly other testing tools) generate instances of :py:class:`Program` that
+    # can not be properly represented.
+    #
+    # I should have at least defined an abstract method such as this one:
+    # @abc.abstractmethod
+    # def __repr__(self) -> str:
+    #     """Represent the instance as a string for debugging."""
+    #     raise NotImplementedError()
 
 
 class Assign(Statement):
@@ -432,19 +438,16 @@ class Assign(Statement):
         self.target = target
         self.expr = expr
 
-    # ERROR (mristin, 2021-06-18):
-    # I forgot to implement a specific ``__eq__`` for the :py:class:`Assign`.
-    # Something like:
-    # def __eq__(self, other: object) -> bool:
-    #     """
-    #     Compare against ``other`` of the same class based on the properties.
-    #
-    #     Otherwise, propagate to :py:attr:`object.__eq__`.
-    #     """
-    #     if isinstance(other, Assign):
-    #         return self.target == other.target and self.expr == other.expr
-    #
-    #     return object.__eq__(self, other)
+    def __eq__(self, other: object) -> bool:
+        """
+        Compare against ``other`` of the same class based on the properties.
+
+        Otherwise, propagate to :py:attr:`object.__eq__`.
+        """
+        if isinstance(other, Assign):
+            return self.target == other.target and self.expr == other.expr
+
+        return object.__eq__(self, other)
 
     def __repr__(self) -> str:
         """Represent the instance as a string for debugging."""
@@ -801,6 +804,7 @@ class _UnparseVisitor(_Visitor[None]):
 @ensure(lambda program, result: parse_program(tokenize(result)) == program)
 def unparse(program: Program) -> str:
     """Convert the AST back to the source code."""
+    print(f"program is {program!r}")  # TODO: debug
     visitor = _UnparseVisitor()
     visitor.visit(program)
 


### PR DESCRIPTION
The class ``Statement`` has not been marked as abstract so it is
automatically generated by icontract-hypothesis. This patch fixes that,
adds a failure case in the curated incorrect solutions and propagates
the fix to the already curated incorrect solutions.