### PR TITLE
Fix ETHZ Eprog 2019 Ex. 12 Prob. 3

### DIFF
--- a/tests/correct/ethz_eprog_2019/exercise_12/test_problem_03.py
+++ b/tests/correct/ethz_eprog_2019/exercise_12/test_problem_03.py
@@ -75,7 +75,7 @@ class TestWithIcontractHypothesis(unittest.TestCase):
 
             try:
                 problem_03.compile_and_execute(program)
-            except (ValueError, OverflowError):
+            except (ValueError, OverflowError, ZeroDivisionError):
                 pass
 
         icontract_hypothesis.test_with_inferred_strategy(restricted)


### PR DESCRIPTION
This patch fixes the test to ignore ``ZeroDivisionError``. The text of
the exercise was underspecified and did not mention what happens when
there is, say, a division by zero.