### PR TITLE
Avoid NaN's in ETHZ Eprog 2019 Ex. 5 Prob. 4

### DIFF
--- a/python_by_contract_corpus/correct/ethz_eprog_2019/exercise_05/problem_04.py
+++ b/python_by_contract_corpus/correct/ethz_eprog_2019/exercise_05/problem_04.py
@@ -17,6 +17,7 @@ The program answers the following questions:
 * What is the total revenue of the hotel for the year?
 """
 import collections
+import math
 from typing import MutableMapping, Collection, List
 
 from icontract import require, ensure, DBC
@@ -44,6 +45,16 @@ class Entry(DBC):
         lambda price_discount: 0 <= price_discount <= 100,
         "The price discount is given as a percentage."
     )
+    @require(
+        lambda price_discount:
+        not math.isnan(price_discount) and price_discount < 1e300,
+        "Reasonable bounds to avoid NaN's and inf's"
+    )
+    @require(
+        lambda price_per_day:
+        not math.isnan(price_per_day) and price_per_day < 1e300,
+        "Reasonable bounds to avoid NaN's and inf's"
+    )
     # fmt: on
     def __init__(
         self,
@@ -64,6 +75,16 @@ class Entry(DBC):
     def duration(self) -> int:
         """Compute the duration of the stay."""
         return self.end - self.start + 1
+
+    def __repr__(self) -> str:
+        return (
+            f"Entry("
+            f"room_number={self.room_number}, "
+            f"start={self.start}, "
+            f"end={self.end}, "
+            f"price_per_day={self.price_per_day}, "
+            f"price_discount={self.price_discount})"
+        )
 
 
 @require(lambda entries: len(entries) > 0)

--- a/tests/correct/ethz_eprog_2019/exercise_05/test_problem_04.py
+++ b/tests/correct/ethz_eprog_2019/exercise_05/test_problem_04.py
@@ -22,5 +22,18 @@ class TestWithIcontractHypothesis(unittest.TestCase):
                 ) from error
 
 
+class TestManually(unittest.TestCase):
+    def test_numerical_edge_case_for_entry_collection(self) -> None:
+        entry = problem_04.Entry(
+            room_number=1,
+            start=1,
+            end=257,
+            price_per_day=6.994914921643253e299,
+            price_discount=0.0,
+        )
+
+        _ = problem_04.total_revenue(entries=[entry])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
We explicitly disallow NaN's and impose large upper bounds in
the pre-conditions of the class `Entry` to avoid problems further
down the line.
