### PR TITLE
Make AoC Day 13 ``wrong_mod`` more tracable

### DIFF
--- a/python_by_contract_corpus/incorrect_from_recorded/aoc2020/day_13_shuttle_search/wrong_mod.py
+++ b/python_by_contract_corpus/incorrect_from_recorded/aoc2020/day_13_shuttle_search/wrong_mod.py
@@ -19,8 +19,11 @@ def next_departure(bus_id: int, min_time: int) -> int:
     """Compute the next departure of ``bus_id`` leaving earliest at ``min_time``."""
     # ERROR (pschanely, 2021-04-19):
     # bus_id and min_time should be reversed here.
-    wait_time = bus_id % min_time
-    return min_time + wait_time
+    missed_last_bus_by = bus_id % min_time
+    if missed_last_bus_by == 0:
+        return min_time
+    else:
+        return min_time - missed_last_bus_by + bus_id
 
 
 @require(lambda start_time: start_time >= 0)


### PR DESCRIPTION
We reduce the diff between the incorrect program and the final solution
even more by masking out the finer unnecessary part of the recorded
error, and keeping only the single most-relevant line.